### PR TITLE
Handle overlays/dropdowns in fullscreen mode

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -12,9 +12,30 @@ export default class FullScreenPlugin extends Plugin {
   onunload() {}
 
   fullscreenMode() {
-    var leaf = <any> this.app.workspace.activeLeaf;
+    var leaf = this.app.workspace.activeLeaf;
     if (!leaf) return;
+    var el = leaf.containerEl;
+    var fullscreenMutationObserver;
 
-    leaf.containerEl.requestFullscreen();
+    el.requestFullscreen();
+
+    // disable mutation observer when exiting fullscreen mode
+    el.addEventListener("fullscreenchange", (event) => {
+      if (!document.fullscreenElement) {
+        fullscreenMutationObserver.disconnect();
+      }
+    });
+
+    // copy all nodes
+    fullscreenMutationObserver = new MutationObserver((mutationRecords) => {
+      mutationRecords.forEach((mutationRecord) => {
+        mutationRecord.addedNodes.forEach((node) => {
+          document.body.removeChild(node);
+          el.appendChild(node);
+        });
+      });
+    });
+
+    fullscreenMutationObserver.observe(document.body, { childList: true });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -34,6 +34,9 @@ export default class FullScreenPlugin extends Plugin {
           el.appendChild(node);
         });
       });
+      // focus on prompt for file open
+      if (document.querySelector(".prompt-input"))
+        document.querySelector(".prompt-input").focus();
     });
 
     fullscreenMutationObserver.observe(document.body, { childList: true });


### PR DESCRIPTION
Fixes https://github.com/Razumihin/obsidian-fullscreen-plugin/issues/1

Issue and solution described here: https://stackoverflow.com/questions/34172591/fullscreen-api-make-fullscreen-element-with-internal-elements-and-save-ability-to-work-dropdown

Overlay and dropdown are attached to document, which is not fullscreen. I made mutation observer that reattach all new nodes(like dropdown and modal) to element that current in fullscreen mode